### PR TITLE
Allow hal_usb access sysfs when in coredomain

### DIFF
--- a/private/domain.te
+++ b/private/domain.te
@@ -41,6 +41,7 @@ full_treble_only(`
     -init
     -ueventd
     -vold
+    -hal_usb
   } sysfs:file no_rw_file_perms;
 
   # /dev


### PR DESCRIPTION
This is necessary if we build a device-specific
USB HAL that is stored in /system/bin/hw.

Change-Id: I610cd9097ac118035a97281bb0465370a435a74d